### PR TITLE
`#[SensitiveParameter]` Attribute Polyfill

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
         "psr-4": {
             "IlicMiljan\\SecureProps\\": "src/"
         },
+        "files": ["src/Attribute/SensitiveParameter.php"],
         "exclude-from-classmap": ["tests/"]
     },
     "autoload-dev": {

--- a/src/Attribute/SensitiveParameter.php
+++ b/src/Attribute/SensitiveParameter.php
@@ -1,0 +1,21 @@
+<?php
+
+// phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+
+/**
+ * Polyfill for the SensitiveParameter attribute introduced in PHP 8.2.
+ *
+ * This polyfill allows code targeting PHP versions earlier than 8.2 to use the
+ * SensitiveParameter attribute without causing syntax errors. It's a no-op in
+ * older PHP versions but enables forward compatibility with PHP 8.2 and newer.
+ */
+
+if (PHP_VERSION_ID < 80200) {
+    #[Attribute(Attribute::TARGET_PARAMETER)]
+    final class SensitiveParameter
+    {
+        public function __construct()
+        {
+        }
+    }
+}


### PR DESCRIPTION
### Description of Changes

Added a polyfill for the `#[SensitiveParameter]` attribute to ensure the codebase is forward-compatible with PHP 8.2 while supporting earlier versions. This polyfill will allow using the `#[SensitiveParameter]` attribute in environments running PHP versions earlier than 8.2 without causing syntax errors.

### How Has This Been Tested?

- **Environment:** Tested on 8.0 in local environment.
- **Method:** Ensured that declaring a function parameter with the `#[SensitiveParameter]` attribute does not cause syntax errors or unexpected behavior. Ran existing unit tests to verify that adding the polyfill does not affect other functionalities.
- **Results:** All tests passed, and the polyfill behaved as expected, mimicking the presence of the `SensitiveParameter` attribute in environments below PHP 8.2.
- 
### Checklist
Please confirm the following:
- [x] I have tested my changes and corrected any errors.
- [x] I have documented my changes if necessary.
