### PR TITLE
Prevent Declaring `#[SensitiveParameter]` Attribute Polyfill Multiple Times

### DIFF
--- a/src/Attribute/SensitiveParameter.php
+++ b/src/Attribute/SensitiveParameter.php
@@ -10,7 +10,7 @@
  * older PHP versions but enables forward compatibility with PHP 8.2 and newer.
  */
 
-if (PHP_VERSION_ID < 80200) {
+if (PHP_VERSION_ID < 80200 && !class_exists('SensitiveParameter')) {
     #[Attribute(Attribute::TARGET_PARAMETER)]
     final class SensitiveParameter
     {


### PR DESCRIPTION
### Description of Changes

Added a `class_exists` check before defining the `SensitiveParameter` polyfill to prevent redeclaration errors and ensure compatibility across different PHP versions and packages.

### How Has This Been Tested?

Tested in environments with and without the polyfill already defined, across PHP versions below 8.2, to ensure no redeclaration errors occur and the polyfill functions as intended.

### Checklist
Please confirm the following:
- [x] I have tested my changes and corrected any errors.
- [x] I have documented my changes if necessary.
