### PR TITLE
Add `Cache` and `Reader` Unit Tests

### DIFF
--- a/tests/Cache/Exception/InvalidCacheKeyTest.php
+++ b/tests/Cache/Exception/InvalidCacheKeyTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace IlicMiljan\SecureProps\Tests\Cache\Exception;
+
+use IlicMiljan\SecureProps\Cache\Exception\InvalidCacheKey;
+use LogicException;
+use PHPUnit\Framework\TestCase;
+
+class InvalidCacheKeyTest extends TestCase
+{
+    private string $cacheKey;
+
+    protected function setUp(): void
+    {
+        $this->cacheKey = 'invalidKey';
+    }
+
+    public function testCanBeCreated(): void
+    {
+        $exception = new InvalidCacheKey($this->cacheKey);
+
+        $this->assertInstanceOf(InvalidCacheKey::class, $exception);
+    }
+
+    public function testReturnsCacheKey(): void
+    {
+        $exception = new InvalidCacheKey($this->cacheKey);
+
+        $this->assertEquals($this->cacheKey, $exception->getCacheKey());
+    }
+
+    public function testPreviousExceptionIsStored(): void
+    {
+        $previous = new LogicException('Previous exception');
+        $exception = new InvalidCacheKey($this->cacheKey, $previous);
+
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Reader/Exception/ObjectPropertyNotFoundTest.php
+++ b/tests/Reader/Exception/ObjectPropertyNotFoundTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace IlicMiljan\SecureProps\Tests\Reader\Exception;
+
+use IlicMiljan\SecureProps\Reader\Exception\ObjectPropertyNotFound;
+use IlicMiljan\SecureProps\Reader\Exception\ReaderException;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class ObjectPropertyNotFoundTest extends TestCase
+{
+    private string $className;
+
+    protected function setUp(): void
+    {
+        $this->className = 'TestClass';
+    }
+
+    public function testCanBeCreated(): void
+    {
+        $exception = new ObjectPropertyNotFound($this->className);
+
+        $this->assertInstanceOf(ObjectPropertyNotFound::class, $exception);
+    }
+
+    public function testReturnsClassName(): void
+    {
+        $exception = new ObjectPropertyNotFound($this->className);
+
+        $this->assertEquals($this->className, $exception->getClassName());
+    }
+
+    public function testPreviousExceptionIsStored(): void
+    {
+        $previous = new RuntimeException('Previous exception');
+        $exception = new ObjectPropertyNotFound($this->className, $previous);
+
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+
+    public function testImplementsReaderExceptionInterface(): void
+    {
+        $exception = new ObjectPropertyNotFound($this->className);
+
+        $this->assertInstanceOf(ReaderException::class, $exception);
+    }
+}


### PR DESCRIPTION
### Description of Changes

This PR introduces unit tests for Cache and Reader functionalities within the library.

Specifically, it adds tests for the `InvalidCacheKey` exception within the `Cache` component and for the `ObjectPropertyNotFound` exception within the `Reader` component. 

### How Has This Been Tested?

The changes have been tested by running the newly added unit tests.

### Checklist
Please confirm the following:
- [x] I have tested my changes and corrected any errors.
- [x] I have documented my changes if necessary.
