### PR TITLE
Require OpenSSL Extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     "license": "MIT",
     "require": {
         "php": ">=8.0",
+        "ext-openssl": "*",
         "psr/cache": "^2.0|^3.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "655bfec16fc7e781b7b3f23e06dc4a70",
+    "content-hash": "3cdff8676de9c4fe3e36864b48232f6d",
     "packages": [
         {
             "name": "psr/cache",
@@ -1947,7 +1947,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.0"
+        "php": ">=8.0",
+        "ext-openssl": "*"
     },
     "platform-dev": [],
     "plugin-api-version": "2.6.0"


### PR DESCRIPTION
### Description of Changes

PHP OpenSSL extension is required by the library for encryption to work, and this PR adds the `ext-openssl` requirement to `composer.json`.

### How Has This Been Tested?

Validated `composer.json` file with `composer validate`.

### Checklist
Please confirm the following:
- [x] I have tested my changes and corrected any errors.
- [x] I have documented my changes if necessary.
