### PR TITLE
[Breaking Change] Rename Cache Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ $cache = new FilesystemAdapter(...);
 // Configure the caching reader
 $reader = new CachingObjectPropertiesReader(
     new RuntimeObjectPropertiesReader(),
-    new ItemPoolCompatibleCache($cache)
+    new CacheItemPoolAdapter($cache)
 );
 
 // Set up the ObjectEncryptionService with the reader

--- a/src/Cache/CacheItemPoolAdapter.php
+++ b/src/Cache/CacheItemPoolAdapter.php
@@ -6,7 +6,7 @@ use IlicMiljan\SecureProps\Cache\Exception\InvalidCacheKey;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Cache\InvalidArgumentException;
 
-class ItemPoolCompatibleCache implements Cache
+class CacheItemPoolAdapter implements Cache
 {
     private CacheItemPoolInterface $cachePool;
 

--- a/tests/Cache/CacheItemPoolAdapterTest.php
+++ b/tests/Cache/CacheItemPoolAdapterTest.php
@@ -3,14 +3,14 @@
 namespace IlicMiljan\SecureProps\Tests\Cache;
 
 use IlicMiljan\SecureProps\Cache\Exception\InvalidCacheKey;
-use IlicMiljan\SecureProps\Cache\ItemPoolCompatibleCache;
+use IlicMiljan\SecureProps\Cache\CacheItemPoolAdapter;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Cache\InvalidArgumentException;
 
-class ItemPoolCompatibleCacheTest extends TestCase
+class CacheItemPoolAdapterTest extends TestCase
 {
     /**
      * @var CacheItemPoolInterface&MockObject
@@ -20,7 +20,7 @@ class ItemPoolCompatibleCacheTest extends TestCase
      * @var CacheItemInterface&MockObject
      */
     private $cacheItem;
-    private ItemPoolCompatibleCache $cache;
+    private CacheItemPoolAdapter $cache;
 
     protected function setUp(): void
     {
@@ -28,7 +28,7 @@ class ItemPoolCompatibleCacheTest extends TestCase
 
         $this->cachePool = $this->createMock(CacheItemPoolInterface::class);
         $this->cacheItem = $this->createMock(CacheItemInterface::class);
-        $this->cache = new ItemPoolCompatibleCache($this->cachePool);
+        $this->cache = new CacheItemPoolAdapter($this->cachePool);
     }
 
     public function testGetWithCacheHit(): void


### PR DESCRIPTION
### Description of Changes

This PR involves renaming the `ItemPoolCompatibleCache` class within the library to `CacheItemPoolAdapter`. The renaming reflects a more intuitive understanding of the class's functionality as an adapter for cache item pools. 

Corresponding unit test class names have also been updated to match the new naming convention.

### How Has This Been Tested?

The PR includes updates to unit tests to reflect the classes' renaming, ensuring that the functionality remains consistent and reliable with the new class names.

### Checklist
Please confirm the following:
- [x] I have tested my changes and corrected any errors.
- [x] I have documented my changes if necessary.
