### PR TITLE
Allow PSR Cache `v1.0.0` Implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": ">=8.0",
         "ext-openssl": "*",
-        "psr/cache": "^2.0|^3.0"
+        "psr/cache": "^1.0|^2.0|^3.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3cdff8676de9c4fe3e36864b48232f6d",
+    "content-hash": "a560561ecc99e8bae2f1932661e9625d",
     "packages": [
         {
             "name": "psr/cache",


### PR DESCRIPTION
### Description of Changes

This PR updates the `composer.json` to allow compatibility with versions `^1.0`, `^2.0`, and `^3.0` of the `psr/cache` interface.

### How Has This Been Tested?

Validating the library's functionality across the newly supported versions of `psr/cache`.

### Checklist

Please confirm the following:
- [x] I have tested my changes and corrected any errors.
- [x] I have documented my changes if necessary.
