### PR TITLE
Allow Placeholder Value When Decryption Fails

### DIFF
--- a/src/Attribute/Encrypted.php
+++ b/src/Attribute/Encrypted.php
@@ -7,21 +7,36 @@ use Attribute;
 /**
  * Marks a property for encryption.
  *
- * Use this attribute to indicate that a specific property within a class should
- * be encrypted when the class is persisted to a database or any other storage
- * medium.
+ * This attribute indicates that a specific property within a class should be
+ * encrypted when the class is saved to a database or other storage medium.
  *
- * The actual encryption and decryption process is expected to be
- * handled by the consuming code or framework.
+ * Additionally, you can specify a nullable placeholder value to be used when
+ * decryption fails. Depending on the configuration of the consuming code or
+ * framework, an exception may be thrown during decryption failure if the
+ * placeholder is null.
+ *
+ * For instance, a consuming application may throw an exception in production
+ * environments to immediately highlight and address decryption issues. On the
+ * other hand, it might be preferable to use a placeholder value to allow for
+ * continued testing in development environments, even if the data is encrypted
+ * with a different key.
  *
  * @example
+ * ```php
  * class User {
- *     #[Encrypted]
+ *     #[Encrypted(placeholder: "********")]
  *     private string $password;
- * }
  *
- * In the above example, the `$password` property of the User class will be
- * marked for encryption.
+ *     #[Encrypted] // Behavior on decryption failure depends on configuration.
+ *     private string $secret;
+ * }
+ * ```
+ *
+ * In the above examples, the `$password` property of the User class will be
+ * marked for encryption, and "********" may be used as a placeholder if the
+ * decryption process fails.
+ * The behavior of the `$secret` property on decryption failure depends on the
+ * configuration.
  *
  * @see Attribute::TARGET_PROPERTY Indicates that this attribute can only be
  *                                 applied to class properties.
@@ -29,4 +44,26 @@ use Attribute;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 class Encrypted
 {
+    /**
+     * Constructs the Encrypted attribute.
+     *
+     * @param string|null $placeholder The placeholder value to use when
+     *                                 decryption fails, or null to indicate
+     *                                 that an exception may be thrown based
+     *                                 on configuration.
+     */
+    public function __construct(
+        private ?string $placeholder = null
+    ) {
+    }
+
+    /**
+     * Retrieves the placeholder value.
+     *
+     * @return string|null The placeholder value.
+     */
+    public function getPlaceholder(): ?string
+    {
+        return $this->placeholder;
+    }
 }

--- a/src/Exception/SingleEncryptedAttributeExpected.php
+++ b/src/Exception/SingleEncryptedAttributeExpected.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace IlicMiljan\SecureProps\Exception;
+
+use RuntimeException;
+use Throwable;
+
+class SingleEncryptedAttributeExpected extends RuntimeException implements EncryptionServiceException
+{
+    public function __construct(
+        private int $count,
+        ?Throwable $previous = null
+    ) {
+        parent::__construct(
+            'Each property must be annotated with a single instance of the Encrypted attribute.',
+            0,
+            $previous
+        );
+    }
+
+    public function getCount(): int
+    {
+        return $this->count;
+    }
+}

--- a/tests/Attribute/EncryptedTest.php
+++ b/tests/Attribute/EncryptedTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace IlicMiljan\SecureProps\Tests\Attribute;
+
+use IlicMiljan\SecureProps\Attribute\Encrypted;
+use PHPUnit\Framework\TestCase;
+
+class EncryptedTest extends TestCase
+{
+    public function testCanBeCreated(): void
+    {
+        $encrypted = new Encrypted();
+
+        $this->assertInstanceOf(Encrypted::class, $encrypted);
+    }
+    public function testCanRetrieveSpecifiedPlaceholder(): void
+    {
+        $placeholder = "********";
+        $encryptedAttribute = new Encrypted(placeholder: $placeholder);
+
+        $this->assertSame($placeholder, $encryptedAttribute->getPlaceholder());
+    }
+
+    public function testDefaultPlaceholderIsNull(): void
+    {
+        $encryptedAttribute = new Encrypted();
+
+        $this->assertNull($encryptedAttribute->getPlaceholder());
+    }
+}

--- a/tests/Attribute/TestAttribute.php
+++ b/tests/Attribute/TestAttribute.php
@@ -7,4 +7,13 @@ use Attribute;
 #[Attribute(Attribute::TARGET_PROPERTY)]
 class TestAttribute
 {
+    public function __construct(
+        private ?string $placeholder = null
+    ) {
+    }
+
+    public function getPlaceholder(): ?string
+    {
+        return $this->placeholder;
+    }
 }


### PR DESCRIPTION
### Description of Changes

Implemented the ability to specify a nullable placeholder for properties with the `Encrypted` attribute. This change allows for customizable handling of decryption failures, enhancing flexibility for development and production environments.

### How Has This Been Tested?

Verifying that the placeholder is used correctly when decryption fails and that an exception is thrown when expected, across various scenarios.

### Checklist
Please confirm the following:
- [x] I have tested my changes and corrected any errors.
- [x] I have documented my changes if necessary.
